### PR TITLE
permit (1) the suppression of results and (2) specification of multiple result formats

### DIFF
--- a/src/fate/cli/command/control.py
+++ b/src/fate/cli/command/control.py
@@ -263,17 +263,21 @@ class ControlCommand(Main):
                 result_path = exc.identifier
 
                 logger.warning(format=exc.format,
-                               error=str(exc.error),
+                               error=(str(exc.errors[0]) if len(exc.errors) == 1
+                                      else [str(error) for error in exc.errors]),
                                msg="bad result encoding for configured format: "
                                    "path suffix ignored")
 
-            try:
-                self.write_result(result_path, task.stdout)
-            except NotADirectoryError as exc:
-                logger.error(f'cannot record result: '
-                             f'path or sub-path is not a directory: {exc.filename}')
-            except PermissionError as exc:
-                logger.error(f'cannot record result: permission denied: {exc.filename}')
+            if result_path:
+                try:
+                    self.write_result(result_path, task.stdout)
+                except NotADirectoryError as exc:
+                    logger.error(f'cannot record result: '
+                                 f'path or sub-path is not a directory: {exc.filename}')
+                except PermissionError as exc:
+                    logger.error(f'cannot record result: permission denied: {exc.filename}')
+            else:
+                logger.debug('result empty or record disabled')
 
     def set_lock(self):
         """Set command's run-time lock.

--- a/src/fate/conf/error.py
+++ b/src/fate/conf/error.py
@@ -40,8 +40,8 @@ class LogsDecodingError(ValueError, ConfError):
 
 class ResultEncodingError(ValueError, ConfError):
 
-    def __init__(self, format_, error, identifier):
-        super().__init__(format_, error, identifier)
+    def __init__(self, format_, errors, identifier):
+        super().__init__(format_, errors, identifier)
         self.format = format_
-        self.error = error
+        self.errors = errors
         self.identifier = identifier

--- a/src/fate/util/format.py
+++ b/src/fate/util/format.py
@@ -157,7 +157,10 @@ class SLoader(_NameList, _Raises, FileFormatEnum, CallableEnum):
         if not format_:
             return (None, None)
 
-        if format_ == 'auto':
+        if format_ == 'auto' or format_ == 'mixed':
+            if not content:
+                return (None, None)
+
             for loader in cls.__auto__:
                 try:
                     result = loader(content, **types)


### PR DESCRIPTION
**result suppression**

* with configuration key `format.result` set to `auto` (*i.e.* by default), *empty* task results are *no longer* recorded -- (no empty result file will be written)

  * the old behavior is preserved by a new option for that key: `mixed`: results' formats are inferred and empty results are written to empty files (without file extensions)

* configuration of an *empty* value (*i.e.* empty string or null) at key `path.result` suppresses writing of the result record entirely (regardless of the above) -- like `/dev/null`

**multiple specification of result format**

configuration key `format.result` *may* now be set to an array (list) of supported result formats -- *e.g.*: `["json", "toml"]`. task results will be tested for validity against each of these in turn (and given the appropriate file extension).