### PR TITLE
added task execution configuration option: shell

### DIFF
--- a/src/fate/util/datastructure/enum.py
+++ b/src/fate/util/datastructure/enum.py
@@ -2,7 +2,25 @@ import enum
 import functools
 
 
-class StrEnum(str, enum.Enum):
+class MixedEnumMeta(enum.EnumMeta):
+
+    # note: override only necessary prior to Python 3.12
+    def __contains__(cls, obj):
+        if not isinstance(obj, enum.Enum):
+            for member in cls:
+                if obj == member.value:
+                    return True
+            else:
+                return False
+
+        return super().__contains__(obj)
+
+
+class MixedEnum(enum.Enum, metaclass=MixedEnumMeta):
+    pass
+
+
+class StrEnum(str, MixedEnum):
 
     def __str__(self):
         return str(self.value)


### PR DESCRIPTION
a task's `shell` setting may be a string or a mapping of:

```
{
    script: str,
    executable: str
}
```

as a simple string, `shell` will be executed by "sh".

supported executables include: sh, bash and python.

all executables are launched passing the shell "script" string as an argument to "-c", *e.g.*:

```sh
sh -c "..."
```

the shell "script" supports template expression interpolation (like "exec") -- in addition to, of course, shell-specific variables and syntax.

for example:

```yaml
clean-tmp:
  shell: find /tmp/ -mindepth 1 -type d -empty -delete

go-nuts:
  shell:
    executable: python
    script: |
      import subprocess

      proc = subprocess.run(['cowsay', '-e', '{{ env.DISPLAY }}'])

      raise SystemExit(proc.returncode)
```

note: this is really just syntactic sugar for the following and can be custom-implemented like the following:

```yaml
exec:
  - perl
  - -e
  - |
    print "Hello World";
```

(or, obviously, via a script file on disk).