### PR TITLE
suppress stack overflow caused by conf-loading descriptors

### DIFF
--- a/src/fate/conf/base/conf.py
+++ b/src/fate/conf/base/conf.py
@@ -8,6 +8,7 @@ from fate.util.datastructure import (
     AttributeDict,
     AttributeAccessMap,
     LazyLoadProxyMapping,
+    loads,
     NestingConf,
     SimpleEnum,
 )
@@ -58,14 +59,17 @@ class Conf(AttributeAccessMap, NestingConf, LazyLoadProxyMapping):
                 f"-> {default}>")
 
     @cachedproperty
+    @loads
     def _indicator_(self):
         return self._prefix_.conf / self.__filename__
 
     @cachedproperty
+    @loads
     def _indicator_builtin_(self):
         return resources.files(self._builtin_.path) / self.__filename__
 
     @cachedproperty
+    @loads
     def __path__(self):
         paths = (self._indicator_.with_suffix(format_.suffix)
                  for format_ in self._Format)
@@ -96,10 +100,12 @@ class Conf(AttributeAccessMap, NestingConf, LazyLoadProxyMapping):
         ))
 
     @property
+    @loads
     def _format_(self):
         return self.__path__.suffix[1:]
 
     @property
+    @loads
     def _loader_(self):
         return self._Format[self._format_]
 

--- a/src/fate/util/datastructure/__init__.py
+++ b/src/fate/util/datastructure/__init__.py
@@ -11,6 +11,7 @@ from .collection import (  # noqa: F401
 
 from .lazy import (  # noqa: F401
     LazyLoadProxyMapping,
+    loads,
 )
 
 from .nesting import (  # noqa: F401

--- a/src/fate/util/datastructure/lazy.py
+++ b/src/fate/util/datastructure/lazy.py
@@ -1,5 +1,7 @@
 import abc
+import functools
 
+from .access import nomap
 from .collection import ProxyMapping
 
 
@@ -58,3 +60,16 @@ class LazyLoadProxyMapping(LazyLoadMap, ProxyMapping):
     """
     def __setdata__(self, data):
         self.__collection__.update(data)
+
+
+class LoadAttributeError(Exception):
+    """Stand-in for `AttributeError`.
+
+    Does *not* extend `AttributeError`, such that descriptors
+    responsible for lazily loading map data may raise it without
+    triggering `__getattr__`.
+
+    """
+
+
+loads = functools.partial(nomap, exc_class=LoadAttributeError)


### PR DESCRIPTION
suppress stack overflow caused by AttributeError raised by conf-loading descriptor

AttributeErrors raised by descriptors involved in loading configuration are swapped with custom LoadAttributeErrors to disable fallback to (as yet unloaded) configuration.

resolves #9