### PR TITLE
compat: Py38: importlib_resources

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ pyyaml = "^6.0"
 schema = "^0.7.5"
 toml = "^0.10.2"
 wcwidth = "^0.2.5"
+importlib-resources = {version = "5.0", python = "3.8"}
 
 [tool.poetry.dev-dependencies]
 # Note: poetry, et al, currently feature no facility to *do* anything

--- a/src/fate/cli/command/control.py
+++ b/src/fate/cli/command/control.py
@@ -7,7 +7,6 @@ import re
 import shutil
 import sys
 import time
-from importlib import resources
 
 import plumbum
 from descriptors import cachedproperty
@@ -15,6 +14,7 @@ from descriptors import cachedproperty
 from fate import sched
 from fate.conf import LogsDecodingError, ResultEncodingError
 from fate.util.argument import ChoiceMapping
+from fate.util.compat import resources
 from fate.util.lazy import lazy_id
 from fate.util.log import StructLogger
 from fate.util.os import pid_exists

--- a/src/fate/conf/base/conf.py
+++ b/src/fate/conf/base/conf.py
@@ -1,9 +1,9 @@
 """In-memory access to supported configuration files."""
-from importlib import resources
 from types import SimpleNamespace
 
 from descriptors import cachedproperty
 
+from fate.util.compat import resources
 from fate.util.datastructure import (
     AttributeDict,
     AttributeAccessMap,

--- a/src/fate/util/compat/resources.py
+++ b/src/fate/util/compat/resources.py
@@ -1,0 +1,24 @@
+#
+# TODO: drop this along with Python v3.8
+#
+# (importlib_resources needed for e.g. files() found only in Python v3.9)
+#
+import importlib
+import itertools
+
+try:
+    import importlib_resources
+except ImportError:
+    importlib_resources = None
+
+
+_target_ = importlib_resources or importlib.import_module('importlib.resources')
+
+
+def __dir__():
+    members = itertools.chain(globals(), dir(_target_))
+    return sorted(members)
+
+
+def __getattr__(name):
+    return getattr(_target_, name)


### PR DESCRIPTION
Python v3.8 only: use backported importlib_resources in place of stdlib importlib.resources.

resolves #11