### PR TITLE
init subcommand: post-installation system initialization

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,8 @@ packages = [{include = "fate", from = "src"}]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-argcmdr = "^0.13.2"
+argcmdr = "^0.14.0"
+argcomplete = "^2.0"
 croniter = "^1.3.5"
 Jinja2 = "^3.1.2"
 loguru = "^0.6.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ packages = [{include = "fate", from = "src"}]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-argcmdr = "^0.14.0"
+argcmdr = "^1.0.0"
 argcomplete = "^2.0"
 croniter = "^1.3.5"
 Jinja2 = "^3.1.2"

--- a/src/fate/cli/__init__.py
+++ b/src/fate/cli/__init__.py
@@ -1,3 +1,3 @@
-from .base import runcmd  # noqa: F401
+from .base import exit_on_error, runcmd  # noqa: F401
 
 from .root import main, Main, daemon, serve  # noqa: F401

--- a/src/fate/cli/base/__init__.py
+++ b/src/fate/cli/base/__init__.py
@@ -1,2 +1,3 @@
-from .execution import runcmd  # noqa: F401
-from .main import Main         # noqa: F401
+from .common import exit_on_error  # noqa: F401
+from .execution import runcmd      # noqa: F401
+from .main import Main             # noqa: F401

--- a/src/fate/cli/base/execution.py
+++ b/src/fate/cli/base/execution.py
@@ -133,7 +133,7 @@ class OneOffExecutor(CommandInterface, argcmdr.Local):
     def prepare(self, args, parser):
         """Execute and report on task command execution."""
         try:
-            command_spec = self.call(args, 'get_command')
+            command_spec = self.delegate('get_command')
         except self.local.CommandNotFound as exc:
             hint = ('\nhint: whitespace in program name suggests a misconfiguration'
                     if re.search(r'\s', exc.program) else '')

--- a/src/fate/cli/base/main.py
+++ b/src/fate/cli/base/main.py
@@ -1,3 +1,6 @@
+import os.path
+import sys
+
 import argcmdr
 
 from .common import CommandInterface
@@ -7,11 +10,12 @@ class Main(CommandInterface, argcmdr.RootCommand):
     """manage the periodic execution of commands"""
 
     @classmethod
-    def base_parser(cls):
-        parser = super().base_parser()
+    def _new_parser_(cls):
+        parser = super()._new_parser_()
 
         # enforce program name when invoked via "python -m fate"
         if parser.prog == '__main__.py':
-            parser.prog = 'fate'
+            command = os.path.basename(sys.executable)
+            parser.prog = f'{command} -m fate'
 
         return parser

--- a/src/fate/cli/command/control.py
+++ b/src/fate/cli/command/control.py
@@ -148,9 +148,7 @@ class ControlCommand(Main):
         error_msg = error and f': {error}'
         error_name = exc.__class__.__name__
 
-        parser = self.args.__parser__
-
-        parser.exit(1, f'{parser.prog}: fatal: {error_name}{error_msg}\n')
+        self.parser.exit(1, f'{self.parser.prog}: fatal: {error_name}{error_msg}\n')
 
     def __call__(self, args, parser):
         """Execute the command."""

--- a/src/fate/cli/command/init.py
+++ b/src/fate/cli/command/init.py
@@ -1,16 +1,21 @@
+import abc
 import enum
 import os
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 
 import argcomplete
 
-from fate.util.argument import FileAccess, access_parent
+from fate.util.abstract import abstractmember
+from fate.util.argument import ChoiceMapping, DirAccess, FileAccess
 from fate.util.compat.argument import BooleanOptionalAction
 from fate.util.datastructure import StrEnum
+from fate.util.format import Loader
+from fate.util.term import getch
 from plumbum import colors
 
-from .. import Main
+from .. import exit_on_error, Main
 
 
 class StatusSymbol(StrEnum):
@@ -38,6 +43,105 @@ class EndStatus(enum.Enum):
 class TaskSymbol(StrEnum):
 
     comp = colors.bold | '↹'
+    conf = colors.bold | '⚙'
+
+
+@dataclass
+class TaskPrompt(abc.ABC):
+
+    identifier: str
+    description: str
+    path: Path
+    exists: bool = True
+    syncd: bool = True
+
+    update_action = abstractmember()
+
+
+class PathOverwrite(TaskPrompt):
+
+    update_action = 'overwrite'
+
+
+class PathUpdate(TaskPrompt):
+
+    update_action = 'update'
+
+
+class InitCommand(Main, metaclass=abc.ABCMeta):
+
+    description = abstractmember()
+    path_access = abstractmember()
+
+    def check_access(self, path):
+        try:
+            self.path_access(path)
+        except self.path_access.PathTypeError:
+            extant_type = 'directory' if isinstance(self.path_access, FileAccess) else 'file'
+
+            self.parser.print_usage(sys.stderr)
+            self.parser.exit(71, f'{self.parser.prog}: fatal: inferred path is '
+                                 f'extant {extant_type}: {path}\n'
+                                 if path.exists() else
+                                 f'{self.parser.prog}: fatal: inferred path is '
+                                 f'inaccessible: {path}\n')
+        except self.path_access.PathAccessError:
+            self.parser.print_usage(sys.stderr)
+            self.parser.exit(73, f'{self.parser.prog}: fatal: inferred path is '
+                                 f'not read-writable: {path}\n')
+
+    @abc.abstractmethod
+    def execute(self):
+        yield from ()
+
+    @exit_on_error
+    def __call__(self, args):
+        executor = self.delegate('execute')
+
+        prompt = next(executor)
+
+        print(StatusSymbol.complete if prompt.syncd else StatusSymbol.incomplete,
+              TaskSymbol[prompt.identifier],
+              colors.underline & colors.dim | str(prompt.path),
+              sep='  ')
+
+        lines = 1
+
+        if args.prompt and not prompt.syncd:
+            lines += 2
+
+            print(
+                '\n_ [Y|n]',
+                colors.warn[prompt.update_action] if prompt.exists else 'install',
+                f'{prompt.description}?',
+                end='\r',  # return
+            )
+
+            while (do_install := getch().lower()) not in 'yn\r\x03\x04':
+                pass
+
+            if do_install == '\r':
+                # set empty
+                do_install = 'y'
+            elif do_install in '\x03\x04':
+                # treat ^C and ^D as input of "n"
+                do_install = 'n'
+
+            print(colors.underline | do_install.upper())
+        else:
+            do_install = 'y'
+
+        status = executor.send(do_install == 'y')
+
+        # update status line
+        print(
+            f'\033[{lines}F',                                     # jump to ☐
+            status.symbol,                                        # reset symbol
+            '\033[{}C'.format(5 + len(str(prompt.path))),         # jump to end
+            f': {prompt.description} {status.message}',           # set message
+            sep='',
+            end=('\n' * lines),                                   # return to bottom
+        )
 
 
 @Main.register
@@ -56,173 +160,223 @@ class Init(Main):
         )
 
     def __call__(self):
-        print(colors.title | 'shell completion', end='\n\n')
+        for (index, subcommand) in enumerate(self):
+            print('' if index == 0 else '\n',
+                  colors.title | subcommand.description,
+                  sep='',
+                  end='\n\n')
 
-        self['comp'].delegate()
+            subcommand.call()
 
-    class Comp(Main):
-        """install shell tab-completion files"""
 
-        script_suffixes = ('', 'd', 's')
+@Init.register
+class Conf(InitCommand):
+    """install configuration files"""
 
-        class Shell(StrEnum):
+    description = 'default configuration'
+    path_access = DirAccess('rw', parents=True)
 
-            bash = 'bash'
-            fish = 'fish'
-            tcsh = 'tcsh'
+    @dataclass
+    class FormatPreference:
 
-            @classmethod
-            def get_choices(cls):
-                return sorted(str(member) for member in cls)
+        name: str
 
-            @classmethod
-            def get_default(cls):
-                login_shell = os.getenv('SHELL')
+        @property
+        def suffix(self):
+            return '.' + self.name
 
-                if not login_shell:
-                    return None
+        def select(self, suffix):
+            return suffix == self.suffix
 
-                shell_path = Path(login_shell)
+        def __str__(self):
+            return self.name
 
-                if not shell_path.is_file():
-                    return None
+    def __init__(self, parser):
+        formats = {loader.name: self.FormatPreference(loader.name) for loader in Loader}
+        parser.add_argument(
+            '--format',
+            action=ChoiceMapping,
+            choices=formats,
+            default=formats['toml'],
+            help="configuration format to prefer (default: %(default)s)",
+        )
 
-                shell_name = shell_path.name
+        parser.add_argument(
+            'path',
+            nargs='?',
+            type=self.path_access,
+            help="force installation to directory path (default: inferred)",
+        )
 
-                return cls.__members__.get(shell_name)
+    def execute(self, args, parser):
+        if args.path:
+            conf_prefix = args.path
+        else:
+            conf_prefix = self.conf._prefix_.conf
 
-        def __init__(self, parser):
-            shell_default = self.Shell.get_default()
-            parser.add_argument(
-                '--shell',
-                choices=self.Shell.get_choices(),
-                default=shell_default,
-                help="shell for which to install completion "
-                     + ("(default: %(default)s)" if shell_default else "(required)"),
-                required=shell_default is None,
-            )
+            self.check_access(conf_prefix)
 
-            target = parser.add_mutually_exclusive_group()
-            target.add_argument(
-                '--system',
-                default=None,
-                dest='system_profile',
-                action='store_true',
-                help="force system-wide installation (default: inferred)",
-            )
-            target.add_argument(
-                '--user',
-                default=None,
-                dest='system_profile',
-                action='store_false',
-                help="force user-only installation (default: inferred)",
-            )
-            target.add_argument(
-                'path',
-                nargs='?',
-                type=FileAccess('rw', parents=True),
-                help="force installation to file at path (default: inferred)",
-            )
+        update_paths = {}
 
-        def __call__(self, args, parser):
-            """install shell completion"""
-            # determine installation path
-            if args.path:
-                completions_path = args.path
-            else:
-                completions_path = self.conf._prefix_.completions(args.shell, args.system_profile)
+        prompt = PathOverwrite('conf', self.description, path=None)
 
-                if completions_path.exists():
-                    access_target = completions_path
+        for conf in self.conf:
+            builtins = {path.suffix: path for path in conf._iter_builtins_()}
 
-                    if access_target.is_dir():
-                        parser.print_usage(sys.stderr)
-                        parser.exit(71, f'{parser.prog}: fatal: inferred path is '
-                                        f'extant directory: {completions_path}\n')
-                else:
-                    access_target = access_parent(completions_path)
+            formats_builtin = sorted(builtins, key=args.format.select, reverse=True)
 
-                    if not access_target.is_dir():
-                        parser.print_usage(sys.stderr)
-                        parser.exit(71, f'{parser.prog}: fatal: inferred path is '
-                                        f'inaccessible: {completions_path}\n')
-
-                if not os.access(access_target, os.R_OK | os.W_OK):
-                    parser.print_usage(sys.stderr)
-                    parser.exit(73, f'{parser.prog}: fatal: inferred path is '
-                                    f'not read-writable: {completions_path}\n')
-
-            # determine file contents
-            entry_points = args.__entry_points__ or [f'{self.conf._lib_}{suffix}'
-                                                     for suffix in self.script_suffixes]
-
-            contents = argcomplete.shellcode(entry_points, shell=args.shell)
-
-            # check file status
             try:
-                up_to_date = completions_path.read_text() == contents
-            except FileNotFoundError:
-                file_exists = up_to_date = False
-            else:
-                file_exists = True
+                format_builtin = formats_builtin[0]
+            except IndexError:
+                parser.print_usage(sys.stderr)
+                parser.exit(70, f"{parser.prog}: fatal: no built-in for "
+                                f"conf file '{conf.__name__}'")
 
-            # print status line
-            print(StatusSymbol.complete if up_to_date else StatusSymbol.incomplete,
-                  TaskSymbol.comp,
-                  colors.underline & colors.dim | str(completions_path),
-                  sep='  ')
-
-            lines = 1
-
-            if up_to_date:
-                status = EndStatus.complete
-            else:
-                if args.prompt:
-                    lines += 2
-
-                    print(
-                        '\n_ [Y|n]',
-                        'update' if file_exists else 'install',
-                        'shell completion?',
-                        end='\r',  # return
-                    )
-
-                    with colors:
-                        colors.underline()  # must be reset by context manager
-
-                        try:
-                            while (do_install := input().lower() or 'y') not in 'yn':
-                                pass
-                        except KeyboardInterrupt:
-                            # treat as input of "n"
-                            do_install = 'n'
-                            print('\r', do_install, ~colors.underline, ' ', sep='')
-                        else:
-                            if do_install == 'y':
-                                # set empty
-                                print('\033[F', 'Y', sep='')
-
+            if extant := conf._get_path_(conf_prefix):
+                if template := builtins.get(extant.suffix):
+                    update_paths[extant] = template
+                    prompt.syncd = prompt.syncd and template.read_text() == extant.read_text()
                 else:
-                    do_install = 'y'
+                    parser.print_usage(sys.stderr)
+                    parser.exit(70, f'{parser.prog}: fatal: no built-in template for format '
+                                    f'{extant.suffix[1:]} of existing conf file: {extant}')
+            else:
+                prompt.exists = prompt.syncd = False
 
-                if do_install == 'y':
-                    try:
-                        completions_path.parent.mkdir(parents=True,
-                                                      exist_ok=True)
-                        completions_path.write_text(contents)
-                    except OSError:
-                        status = EndStatus.failed
-                    else:
-                        status = EndStatus.complete
-                else:
-                    status = EndStatus.incomplete
+                template = builtins[format_builtin]
+                target_path = conf_prefix / template.name
+                update_paths[target_path] = template
 
-            # update status line
-            print(
-                f'\033[{lines}F',                                     # jump to ☐
-                status.symbol,                                        # reset symbol
-                '\033[{}C'.format(5 + len(str(completions_path))),    # jump to end
-                f': {args.shell} shell completion {status.message}',  # set message
-                sep='',
-                end=('\n' * lines),                                   # return to bottom
-            )
+        pseudo_name = '{%s}' % ','.join(path.name for path in update_paths)
+        prompt.path = conf_prefix / pseudo_name
+
+        confirmed = yield prompt
+
+        if prompt.syncd:
+            yield EndStatus.complete
+        elif confirmed:
+            try:
+                conf_prefix.mkdir(parents=True, exist_ok=True)
+
+                for (target_path, source_path) in update_paths.items():
+                    with target_path.open('wb') as t_fd, source_path.open('rb') as s_fd:
+                        t_fd.writelines(s_fd)
+            except OSError:
+                yield EndStatus.failed
+            else:
+                yield EndStatus.complete
+        else:
+            yield EndStatus.incomplete
+
+
+@Init.register
+class Comp(InitCommand):
+    """install shell tab-completion files"""
+
+    description = 'shell completion'
+    path_access = FileAccess('rw', parents=True)
+
+    script_suffixes = ('', 'd', 's')
+
+    class Shell(StrEnum):
+
+        bash = 'bash'
+        fish = 'fish'
+        tcsh = 'tcsh'
+
+        @classmethod
+        def get_choices(cls):
+            return sorted(str(member) for member in cls)
+
+        @classmethod
+        def get_default(cls):
+            login_shell = os.getenv('SHELL')
+
+            if not login_shell:
+                return None
+
+            shell_path = Path(login_shell)
+
+            if not shell_path.is_file():
+                return None
+
+            shell_name = shell_path.name
+
+            return cls.__members__.get(shell_name)
+
+    def __init__(self, parser):
+        shell_default = self.Shell.get_default()
+        parser.add_argument(
+            '--shell',
+            choices=self.Shell.get_choices(),
+            default=shell_default,
+            help="shell for which to install completion "
+                 + ("(default: %(default)s)" if shell_default else "(required)"),
+            required=shell_default is None,
+        )
+
+        target = parser.add_mutually_exclusive_group()
+        target.add_argument(
+            '--system',
+            default=None,
+            dest='system_profile',
+            action='store_true',
+            help="force system-wide installation (default: inferred)",
+        )
+        target.add_argument(
+            '--user',
+            default=None,
+            dest='system_profile',
+            action='store_false',
+            help="force user-only installation (default: inferred)",
+        )
+        target.add_argument(
+            'path',
+            nargs='?',
+            type=self.path_access,
+            help="force installation to file at path (default: inferred)",
+        )
+
+    def execute(self, args):
+        """install shell completion"""
+        # determine installation path
+        if args.path:
+            completions_path = args.path
+        else:
+            completions_path = self.conf._prefix_.completions(args.shell, args.system_profile)
+
+            self.check_access(completions_path)
+
+        # determine file contents
+        entry_points = args.__entry_points__ or [f'{self.conf._lib_}{suffix}'
+                                                 for suffix in self.script_suffixes]
+
+        contents = argcomplete.shellcode(entry_points, shell=args.shell)
+
+        # check file status and prepare prompt
+        prompt = PathUpdate('comp', f'{args.shell} {self.description}', completions_path)
+
+        try:
+            prompt.syncd = completions_path.read_text() == contents
+        except FileNotFoundError:
+            prompt.exists = prompt.syncd = False
+        else:
+            prompt.exists = True
+
+        # delegate prompt to controller
+        confirmed = yield prompt
+
+        # complete execution
+        if prompt.syncd:
+            yield EndStatus.complete
+        elif confirmed:
+            try:
+                completions_path.parent.mkdir(parents=True,
+                                              exist_ok=True)
+                completions_path.write_text(contents)
+            except OSError:
+                yield EndStatus.failed
+            else:
+                yield EndStatus.complete
+        else:
+            yield EndStatus.incomplete

--- a/src/fate/cli/command/init.py
+++ b/src/fate/cli/command/init.py
@@ -207,6 +207,8 @@ class Init(Main):
 
                 if do_install == 'y':
                     try:
+                        completions_path.parent.mkdir(parents=True,
+                                                      exist_ok=True)
                         completions_path.write_text(contents)
                     except OSError:
                         status = EndStatus.failed

--- a/src/fate/cli/command/init.py
+++ b/src/fate/cli/command/init.py
@@ -1,0 +1,226 @@
+import enum
+import os
+import sys
+from pathlib import Path
+
+import argcomplete
+
+from fate.util.argument import FileAccess, access_parent
+from fate.util.compat.argument import BooleanOptionalAction
+from fate.util.datastructure import StrEnum
+from plumbum import colors
+
+from .. import Main
+
+
+class StatusSymbol(StrEnum):
+
+    complete   = colors.bold & colors.success | '☑'  # noqa: E221
+    failed     = colors.bold & colors.fatal   | '☒'  # noqa: E221
+    incomplete = colors.bold & colors.info    | '☐'  # noqa: E221
+
+
+class EndStatus(enum.Enum):
+
+    complete   = (StatusSymbol.complete,   'installed')  # noqa: E221,E241
+    failed     = (StatusSymbol.failed,     'failed')     # noqa: E221,E241
+    incomplete = (StatusSymbol.incomplete, 'skipped')    # noqa: E221,E241
+
+    @property
+    def symbol(self):
+        return self.value[0]
+
+    @property
+    def message(self):
+        return self.value[1]
+
+
+class TaskSymbol(StrEnum):
+
+    comp = colors.bold | '↹'
+
+
+@Main.register
+class Init(Main):
+    """post-installation initializations"""
+
+    def __init__(self, parser):
+        tty_detected = sys.stdin.isatty()
+        prompt_default = 'prompt' if tty_detected else 'no prompt'
+
+        parser.add_argument(
+            '--prompt',
+            default=tty_detected,
+            action=BooleanOptionalAction,
+            help=f"prompt to confirm actions via TTY (default: {prompt_default})",
+        )
+
+    def __call__(self):
+        print(colors.title | 'shell completion', end='\n\n')
+
+        self['comp'].delegate()
+
+    class Comp(Main):
+        """install shell tab-completion files"""
+
+        script_suffixes = ('', 'd', 's')
+
+        class Shell(StrEnum):
+
+            bash = 'bash'
+            fish = 'fish'
+            tcsh = 'tcsh'
+
+            @classmethod
+            def get_choices(cls):
+                return sorted(str(member) for member in cls)
+
+            @classmethod
+            def get_default(cls):
+                login_shell = os.getenv('SHELL')
+
+                if not login_shell:
+                    return None
+
+                shell_path = Path(login_shell)
+
+                if not shell_path.is_file():
+                    return None
+
+                shell_name = shell_path.name
+
+                return cls.__members__.get(shell_name)
+
+        def __init__(self, parser):
+            shell_default = self.Shell.get_default()
+            parser.add_argument(
+                '--shell',
+                choices=self.Shell.get_choices(),
+                default=shell_default,
+                help="shell for which to install completion "
+                     + ("(default: %(default)s)" if shell_default else "(required)"),
+                required=shell_default is None,
+            )
+
+            target = parser.add_mutually_exclusive_group()
+            target.add_argument(
+                '--system',
+                default=None,
+                dest='system_profile',
+                action='store_true',
+                help="force system-wide installation (default: inferred)",
+            )
+            target.add_argument(
+                '--user',
+                default=None,
+                dest='system_profile',
+                action='store_false',
+                help="force user-only installation (default: inferred)",
+            )
+            target.add_argument(
+                'path',
+                nargs='?',
+                type=FileAccess('rw', parents=True),
+                help="force installation to file at path (default: inferred)",
+            )
+
+        def __call__(self, args, parser):
+            """install shell completion"""
+            # determine installation path
+            if args.path:
+                completions_path = args.path
+            else:
+                completions_path = self.conf._prefix_.completions(args.shell, args.system_profile)
+
+                if completions_path.exists():
+                    access_target = completions_path
+
+                    if access_target.is_dir():
+                        parser.print_usage(sys.stderr)
+                        parser.exit(71, f'{parser.prog}: fatal: inferred path is '
+                                        f'extant directory: {completions_path}\n')
+                else:
+                    access_target = access_parent(completions_path)
+
+                    if not access_target.is_dir():
+                        parser.print_usage(sys.stderr)
+                        parser.exit(71, f'{parser.prog}: fatal: inferred path is '
+                                        f'inaccessible: {completions_path}\n')
+
+                if not os.access(access_target, os.R_OK | os.W_OK):
+                    parser.print_usage(sys.stderr)
+                    parser.exit(73, f'{parser.prog}: fatal: inferred path is '
+                                    f'not read-writable: {completions_path}\n')
+
+            # determine file contents
+            entry_points = args.__entry_points__ or [f'{self.conf._lib_}{suffix}'
+                                                     for suffix in self.script_suffixes]
+
+            contents = argcomplete.shellcode(entry_points, shell=args.shell)
+
+            # check file status
+            try:
+                up_to_date = completions_path.read_text() == contents
+            except FileNotFoundError:
+                file_exists = up_to_date = False
+            else:
+                file_exists = True
+
+            # print status line
+            print(StatusSymbol.complete if up_to_date else StatusSymbol.incomplete,
+                  TaskSymbol.comp,
+                  colors.underline & colors.dim | str(completions_path),
+                  sep='  ')
+
+            lines = 1
+
+            if up_to_date:
+                status = EndStatus.complete
+            else:
+                if args.prompt:
+                    lines += 2
+
+                    print(
+                        '\n_ [Y|n]',
+                        'update' if file_exists else 'install',
+                        'shell completion?',
+                        end='\r',  # return
+                    )
+
+                    with colors:
+                        colors.underline()  # must be reset by context manager
+
+                        try:
+                            while (do_install := input().lower() or 'y') not in 'yn':
+                                pass
+                        except KeyboardInterrupt:
+                            # treat as input of "n"
+                            do_install = 'n'
+                            print('\r', do_install, ~colors.underline, ' ', sep='')
+                        else:
+                            if do_install == 'y':
+                                # set empty
+                                print('\033[F', 'Y', sep='')
+
+                else:
+                    do_install = 'y'
+
+                if do_install == 'y':
+                    try:
+                        completions_path.write_text(contents)
+                    except OSError:
+                        status = EndStatus.failed
+                    else:
+                        status = EndStatus.complete
+                else:
+                    status = EndStatus.incomplete
+
+            # update status line
+            print(
+                f'\033[{lines}F',                                     # jump to ☐
+                status.symbol,                                        # reset symbol
+                '\033[{}C'.format(5 + len(str(completions_path))),    # jump to end
+                f': {args.shell} shell completion {status.message}',  # set message
+                sep='',
+                end=('\n' * lines),                                   # return to bottom
+            )

--- a/src/fate/cli/root.py
+++ b/src/fate/cli/root.py
@@ -6,10 +6,11 @@ import fate.cli.command
 from fate.cli.base import Main
 
 
-def extend_parser(parser, conf=None, banner_path=None):
+def extend_parser(parser, conf=None, banner_path=None, entry_points=None):
     parser.set_defaults(
         __conf__=conf,
         __banner_path__=banner_path,
+        __entry_points__=entry_points,
     )
 
 

--- a/src/fate/conf/base/conf_group.py
+++ b/src/fate/conf/base/conf_group.py
@@ -80,7 +80,7 @@ class ConfGroup:
 
     @cachedproperty
     def _prefix_(self):
-        return PrefixPaths._infer(self._lib_)
+        return PrefixPaths.infer(self._lib_)
 
     def _iter_conf_(self, specs):
         for spec in (specs or self._Spec):

--- a/src/fate/util/argument.py
+++ b/src/fate/util/argument.py
@@ -1,4 +1,9 @@
 import argparse
+import enum
+import functools
+import operator
+import os
+import pathlib
 
 
 class ChoiceMapping(argparse.Action):
@@ -13,3 +18,91 @@ class ChoiceMapping(argparse.Action):
 
     def __call__(self, parser, namespace, value, option_string=None):
         setattr(namespace, self.dest, self.mapping[value])
+
+
+def access_parent(path):
+    access_target = path
+
+    while not access_target.exists() and access_target.name != '':
+        access_target = access_target.parent
+
+    return access_target
+
+
+class PathAccess:
+    """Argparse type ensuring filesystem access to given path argument.
+
+    An instance of pathlib.Path is returned.
+
+    """
+    class Access(enum.IntFlag):
+
+        r = os.R_OK
+        w = os.W_OK
+
+        @property
+        def mode(self):
+            #
+            # note: enum has various internal means of determining contents of
+            # a composite flag until proper instance iteration lands in 3.11 or
+            # so.
+            #
+            # rather than worrying about that, here we determine contained names
+            # manually. in 3.11 should be even simpler.
+            #
+            return ''.join(member.name for member in self.__class__ if member in self)
+
+        def ok(self, path):
+            return os.access(path, self)
+
+    def __init__(self, mode, parents=False):
+        if isinstance(mode, str):
+            self.access = functools.reduce(operator.or_, (self.Access[part] for part in mode))
+        elif isinstance(mode, int):
+            self.access = self.Access(mode)
+        elif isinstance(mode, self.Access):
+            self.access = mode
+        else:
+            raise TypeError('expected access mode of type str, int or Access '
+                            'not ' + mode.__class__.__name__)
+
+        self.parents = parents
+
+    def __call__(self, value):
+        path = pathlib.Path(value)
+
+        access_target = access_parent(path) if self.parents else path
+
+        if not self.access.ok(access_target):
+            raise argparse.ArgumentTypeError("failed to access path with mode "
+                                             f"{self.access.mode}: {path}")
+
+        return path
+
+
+class FileAccess(PathAccess):
+
+    def __call__(self, value):
+        path = super().__call__(value)
+
+        if self.parents and not path.exists():
+            if not access_parent(path).is_dir():
+                raise argparse.ArgumentTypeError(f"path inaccessible: {path}")
+        elif not path.is_file():
+            raise argparse.ArgumentTypeError(f"path must be file: {path}")
+
+        return path
+
+
+class DirAccess(PathAccess):
+
+    def __call__(self, value):
+        path = super().__call__(value)
+
+        if self.parents and not path.exists():
+            if not access_parent(path).is_dir():
+                raise argparse.ArgumentTypeError(f"path inaccessible: {path}")
+        elif not path.is_dir():
+            raise argparse.ArgumentTypeError(f"path must be directory: {path}")
+
+        return path

--- a/src/fate/util/compat/argument.py
+++ b/src/fate/util/compat/argument.py
@@ -1,0 +1,60 @@
+import argparse
+import sys
+
+
+if sys.version_info < (3, 9):
+    # backport BooleanOptionalAction
+
+    class BooleanOptionalAction(argparse.Action):
+
+        def __init__(self,
+                     option_strings,
+                     dest,
+                     default=None,
+                     type=None,
+                     choices=None,
+                     required=False,
+                     help=None,
+                     metavar=None):
+
+            _option_strings = []
+            for option_string in option_strings:
+                _option_strings.append(option_string)
+
+                if option_string.startswith('--'):
+                    option_string = '--no-' + option_string[2:]
+                    _option_strings.append(option_string)
+
+            super().__init__(
+                option_strings=_option_strings,
+                dest=dest,
+                nargs=0,
+                default=default,
+                type=type,
+                choices=choices,
+                required=required,
+                help=help,
+                metavar=metavar)
+
+        def __call__(self, parser, namespace, values, option_string=None):
+            if option_string in self.option_strings:
+                setattr(namespace, self.dest, not option_string.startswith('--no-'))
+
+        def format_usage(self):
+            return ' | '.join(self.option_strings)
+
+elif sys.version_info < (3, 12):
+    # fix BooleanOptionalAction help
+    #
+    # see: https://github.com/python/cpython/issues/83137
+    #
+    class BooleanOptionalAction(argparse.BooleanOptionalAction):
+
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+
+            if self.help.endswith(' (default: %(default)s)'):
+                self.help = self.help[:-23]
+
+else:
+    BooleanOptionalAction = argparse.BooleanOptionalAction

--- a/src/fate/util/term.py
+++ b/src/fate/util/term.py
@@ -1,0 +1,22 @@
+import sys
+import tty
+import termios
+
+
+def getch(n=1, /, file=sys.stdin):
+    """Get n character(s) from TTY file."""
+    fd = file.fileno()
+    old = termios.tcgetattr(fd)
+
+    try:
+        tty.setraw(fd)
+        return file.read(n)
+    finally:
+        termios.tcsetattr(fd, termios.TCSADRAIN, old)
+
+
+def getche(n=1, /, infile=sys.stdin, outfile=sys.stdout, end=''):
+    """Print back input from getch."""
+    result = getch(n, infile)
+    print(result, end=end, file=outfile)
+    return result


### PR DESCRIPTION
Adds subcommand `init` with its own subcommands:

* `conf`: write default/example conf files to default directory or to a specified directory

* `comp`: write shell completion files for user or system or to a specified directory

Part of #15 