### PR TITLE
sdk: ignore tty input unless forced by environment variable

### DIFF
--- a/src/fate/cli/base/execution.py
+++ b/src/fate/cli/base/execution.py
@@ -153,7 +153,11 @@ class OneOffExecutor(CommandInterface, argcmdr.Local):
         else:
             (task_name, command) = (None, command_args)
 
-        result = yield command
+        # it's assumed that even if stdin is set to a TTY it's purposeful
+        # here; so, indicate to task.param.read() not to worry about it:
+        bound = command.with_env(FATE_READ_TTY_PARAM='1')
+
+        result = yield bound
 
         if send:
             try:

--- a/src/fate/task/param.py
+++ b/src/fate/task/param.py
@@ -1,5 +1,6 @@
 """Task parameterized input handling."""
 import functools
+import os
 import sys
 
 from schema import Schema
@@ -41,7 +42,7 @@ def read(*, schema=None, empty=Infer, format='auto', file=sys.stdin):
         else:
             empty = None
 
-    if stdin := file.read():
+    if (not file.isatty() or os.getenv('FATE_READ_TTY_PARAM') == '1') and (stdin := file.read()):
         try:
             (params, _loader) = SLoader.autoload(stdin, format, dict_=AttributeDict)
         except SLoader.NonAutoError:


### PR DESCRIPTION
task executables making use of the sdk helper `task.param.read` should support naive shell execution, *e.g.*:

    $ my-command

wherein the shell sets the command's stdin to the shell TTY, even though the user is not necessarily expecting to input task parameters.

in the previously-existing implementation, the above invocation caused the command to hang until the user, unprompted, input the end-of- document control character.

executables using the sdk will now **ignore** tty inputs, unless this functionality is explicitly enabled via environment variable:

    FATE_READ_TTY_PARAM=1

this should make no difference to scheduled task execution, which of course does not permit TTY input.

on the other hand, the debug commands either read parameters from configuration (like scheduled execution); or read parameters from their argumentation; or pass parameters through their own stdin. for the last case, the user has already explicitly indicated their intention; as such, these commands now set the environment variable to force reading of any attached TTY.