### PR TITLE
task state persistence

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,10 +12,12 @@ packages = [{include = "fate", from = "src"}]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-argcmdr = "^1.0.0"
+argcmdr = "^1.0.1"
 argcomplete = "^2.0"
 croniter = "^1.3.5"
+Dickens = "^2.1"
 Jinja2 = "^3.1.2"
+lmdb-dict-full = ">=1.0.2"
 loguru = "^0.6.0"
 pyyaml = "^6.0"
 schema = "^0.7.5"
@@ -27,7 +29,7 @@ importlib-resources = {version = "5.0", python = ">= 3.8, < 3.10"}
 # Note: poetry, et al, currently feature no facility to *do* anything
 # with this optional, dev requirement. rather, this is listed purely as
 # metadata record or note.
-ipdb = {version = "^0.13.9", optional = true}
+ipdb = {version = "^0.13.13", optional = true}
 
 [tool.poetry.scripts]
 fate = "fate:main"

--- a/src/fate/cli/command/control.py
+++ b/src/fate/cli/command/control.py
@@ -22,6 +22,13 @@ from fate.util.os import pid_exists
 from .. import Main
 
 
+def snip(text, length=36, ellipsis=' ...'):
+    if len(text) <= length:
+        return text
+
+    return text[:length - len(ellipsis)] + ellipsis
+
+
 class ControlCommand(Main):
     """Base command class for concrete implementations of the task
     controller command.
@@ -248,7 +255,7 @@ class ControlCommand(Main):
         }
 
         if status is self.CommandStatus.Error:
-            logger.error(status_record, stdout=task.stdout, stderr=task.stderr)
+            logger.error(status_record, stdout=snip(task.stdout), stderr=snip(task.stderr))
         else:
             logger.info(status_record)
 

--- a/src/fate/conf/__init__.py
+++ b/src/fate/conf/__init__.py
@@ -10,6 +10,7 @@ from .error import (  # noqa: F401
     MultiConfError,
     NoConfError,
     ResultEncodingError,
+    StateEncodingError,
 )
 
 

--- a/src/fate/conf/error.py
+++ b/src/fate/conf/error.py
@@ -47,6 +47,14 @@ class ResultEncodingError(ValueError, ConfError):
         self.identifier = identifier
 
 
+class StateEncodingError(ValueError, ConfError):
+
+    def __init__(self, format_, error):
+        super().__init__(format_, error)
+        self.format = format_
+        self.error = error
+
+
 class ConfBracketError(ValueError, ConfError):
 
     message = ('expression SHOULD NOT be enclosed by brackets '

--- a/src/fate/conf/types/task.py
+++ b/src/fate/conf/types/task.py
@@ -54,6 +54,7 @@ class TaskConfType(ConfType):
         param = 'json'
         log = 'auto'
         result = 'auto'
+        state = 'auto'
 
     class _DefaultScheduling(IntEnum):
 

--- a/src/fate/sched/base/scheduler.py
+++ b/src/fate/sched/base/scheduler.py
@@ -10,6 +10,7 @@ from fate.util.animals import animals
 from fate.util.iteration import storeresult
 
 from .scheduled_task import ScheduledTask
+from .state import TaskStateManager
 from .timing import SchedulerTiming
 from .util.reset import resets, Resets
 
@@ -69,7 +70,15 @@ class TaskScheduler(Resets):
     @resets
     @cachedproperty
     def timing(self):
-        return SchedulerTiming(self.conf, self.logger, self.path_state)
+        return SchedulerTiming(
+            self.conf,
+            self.logger,
+            self.path_state / 'check',
+        )
+
+    @cachedproperty
+    def state(self):
+        return TaskStateManager(self.path_state / 'state')
 
     @cachedproperty
     def path_state(self):
@@ -172,7 +181,7 @@ class TaskScheduler(Resets):
                                      msg='skipped: suppressed by if/unless condition')
                     continue
 
-                yield ScheduledTask.schedule(task)
+                yield ScheduledTask.schedule(task, state=self.state.bind(task))
 
     def collect_tasks(self, reset=False):
         """Generate ScheduledTasks to be executed.

--- a/src/fate/sched/base/state.py
+++ b/src/fate/sched/base/state.py
@@ -1,0 +1,156 @@
+"""Task-state connector"""
+from lmdb_dict import CachedLmdbDict
+
+from fate.conf import ConfValueError, StateEncodingError
+
+
+class BoundTaskStateManager:
+    """Interface to a `TaskStateManager` bound to a specified task.
+
+    All methods will return results serialized for consumption by the
+    bound task. Methods do not require specification of the requesting
+    task.
+
+    """
+    def __init__(self, manager, task):
+        self.manager = manager
+        self.task = task
+
+    def read(self):
+        return self.manager.read(self.task)
+
+    def write(self, output):
+        self.manager.write(self.task, output)
+
+    def read_all(self):
+        return self.manager.read_all(self.task)
+
+
+class TaskStateManager:
+    """Task state input and output in the configured serialization
+    format of the requesting task.
+
+    Values are cached in memory to avoid redundant serializations.
+
+    """
+    class _AutoEncodingError(Exception):
+        pass
+
+    def __init__(self, state_path):
+        self.db = CachedLmdbDict(state_path)
+
+        self._l_cache_ = {}
+        self._g_cache_ = {}
+
+    @staticmethod
+    def _format_dump(task):
+        format_ = task.format_['state']
+
+        if format_ == 'auto':
+            return task.format_['param']
+
+        return format_
+
+    @classmethod
+    def _dump_state(cls, task, data):
+        format_ = cls._format_dump(task)
+
+        try:
+            dumper = task._Dumper[format_]
+        except KeyError:
+            raise ConfValueError(
+                f'{task.__name__}: unsupported state serialization format: '
+                f"{format_!r} (select from: {task._Dumper.__names__})"
+            )
+        else:
+            return dumper(data)
+
+    @classmethod
+    def _load_state(cls, task, output):
+        format_ = task.format_['state']
+
+        try:
+            (data, loader) = task._Loader.autoload(output, format_)
+        except task._Loader.NonAutoError:
+            pass
+        else:
+            if loader is None:
+                raise cls._AutoEncodingError
+
+            return data
+
+        try:
+            loader = task._Loader[format_]
+        except KeyError:
+            raise ConfValueError(
+                task._serializer_error.format(
+                    conf_path=f'{task.__name__}.format.state',
+                    format_=format_,
+                )
+            )
+
+        try:
+            return loader(output)
+        except loader.raises as exc:
+            raise StateEncodingError(format_, exc)
+
+    def bind(self, task):
+        return BoundTaskStateManager(self, task)
+
+    def read(self, task):
+        """Retrieve task's state in its preferred serialization format.
+
+        Returns None if task has stored no state.
+
+        """
+        if task.__name__ not in self._l_cache_:
+            data = self.db.get(task.__name__, '')
+
+            if isinstance(data, str):
+                serialization = data
+            else:
+                serialization = self._dump_state(task, data)
+
+            self._l_cache_[task.__name__] = serialization
+
+            return serialization
+
+        return self._l_cache_[task.__name__]
+
+    def write(self, task, output):
+        """Persist task's written output state.
+
+        Does nothing if written output is empty or if it does not differ
+        from cached state.
+
+        """
+        if not output or output == self._l_cache_.get(task.__name__):
+            return
+
+        # update caches
+        self._g_cache_.clear()
+        self._l_cache_[task.__name__] = output
+
+        # deserialize output
+        try:
+            data = self._load_state(task, output)
+        except self._AutoEncodingError:
+            data = output
+
+        # update db
+        self.db[task.__name__] = data
+
+    def read_all(self, task):
+        """Serialize all tasks' states in given task's preferred format.
+
+        """
+        format_ = self._format_dump(task)
+
+        if format_ not in self._g_cache_:
+            serialization = self._dump_state(task, self.db)
+
+            self._g_cache_[format_] = serialization
+
+            return serialization
+
+        return self._g_cache_[format_]

--- a/src/fate/sched/base/timing.py
+++ b/src/fate/sched/base/timing.py
@@ -1,0 +1,77 @@
+import os
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+from descriptors import cachedproperty
+
+from fate.conf import ConfGroup
+from fate.util.log import StructLogger
+
+
+@dataclass
+class SchedulerTiming:
+    """TaskScheduler timing.
+
+    Features stable (caching) properties for the scheduler's last check,
+    current check and when it should next check.
+
+    All such properties return timestamps.
+
+    """
+    conf: ConfGroup
+    logger: StructLogger
+    state_path: Path
+
+    @property
+    def path_check(self):
+        """Path to empty file with which time of last check is stored."""
+        return self.state_path / 'check'
+
+    @cachedproperty
+    def time_check(self):
+        return time.time()
+
+    @cachedproperty
+    def last_check(self):
+        return self._check_state_(update=True)
+
+    @property
+    def next_check(self):
+        return self._next_check_tasks_ or self._next_check_max_
+
+    def _check_state_(self, update=False):
+        try:
+            stat_result = os.stat(self.path_check)
+        except FileNotFoundError:
+            last_check = None
+        else:
+            last_check = stat_result.st_mtime
+
+        if update:
+            if not self.path_check.exists():
+                self.path_check.touch()
+
+            os.utime(self.path_check, (self.time_check, self.time_check))
+
+        return last_check
+
+    @cachedproperty
+    def _next_check_tasks_(self):
+        next_check = None
+
+        for task in self.conf.task.values():
+            next_check = task.schedule_next_(
+                self.time_check,             # t0
+                next_check,                  # t1
+                next_check,                  # default
+                max_years_between_matches=1  # quit if it's that far out
+            )
+
+        return next_check
+
+    _next_max_ = 60 * 60 * 24 * 365  # 1 year in seconds
+
+    @property
+    def _next_check_max_(self):
+        return self.time_check + self._next_max_

--- a/src/fate/sched/base/timing.py
+++ b/src/fate/sched/base/timing.py
@@ -21,12 +21,8 @@ class SchedulerTiming:
     """
     conf: ConfGroup
     logger: StructLogger
-    state_path: Path
-
-    @property
-    def path_check(self):
-        """Path to empty file with which time of last check is stored."""
-        return self.state_path / 'check'
+    path_check: Path        # path to empty file with which time of last
+                            # check is stored               # noqa: E116
 
     @cachedproperty
     def time_check(self):

--- a/src/fate/sched/tiered_tenancy.py
+++ b/src/fate/sched/tiered_tenancy.py
@@ -68,7 +68,7 @@ class TieredTenancyScheduler(TaskScheduler):
                     pool.expand(queue.tenancy_tasks(min_tenancy), size=min_tenancy)
                     self.logger.debug(tenancy=pool.size, active=pool.count, msg='expanded pool')
 
-                if time.time() >= self.next_check:
+                if time.time() >= self.timing.next_check:
                     tasks_1 = self.collect_tasks(reset=True)
                     queue.append(tasks_1)
 

--- a/src/fate/task/__init__.py
+++ b/src/fate/task/__init__.py
@@ -2,4 +2,5 @@ from . import (  # noqa: F401
     log,
     param,
     result,
+    state,
 )

--- a/src/fate/task/state/__init__.py
+++ b/src/fate/task/state/__init__.py
@@ -1,0 +1,1 @@
+from .self import read, write, __doc__  # noqa: F401

--- a/src/fate/task/state/self.py
+++ b/src/fate/task/state/self.py
@@ -1,0 +1,86 @@
+"""Task state persistence via file descriptor input and output."""
+import functools
+
+from fate.util.format import Dumper, SLoader
+
+
+def _ignore_bfd(func):
+    """Decorator suppressing exceptions regarding bad file descriptors.
+
+    Should the decorated function raise an `OSError` exception whose
+    `errno` is set to `9` -- indicating a bad file descriptor -- the
+    exception will be silently suppressed.
+
+    In this case, `None` is returned in lieu of the decorated function's
+    typical result (if any).
+
+    """
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except OSError as exc:
+            #
+            # errno 9 -- bad file descriptor -- suggests we're just not in the scheduler
+            #
+            # (that should be OK)
+            #
+            if exc.errno != 9:
+                raise
+
+    return wrapper
+
+
+@_ignore_bfd
+def read(*, format='auto', fd=3):
+    """Load (parameterized) state from file descriptor `fd` (defaulting
+    to the Fate standard state input descriptor).
+
+    Input is deserialized "auto-magically" according to `format`
+    (defaulting to `auto`). The input serialization format may be
+    specified as one of: `{}`.
+
+    """
+    with open(fd) as file:
+        data = file.read()
+
+    try:
+        (state, _loader) = SLoader.autoload(data, format)
+    except SLoader.NonAutoError:
+        pass
+    else:
+        return state
+
+    try:
+        loader = SLoader[format]
+    except KeyError:
+        raise ValueError(f"unsupported format: {format!r}")
+
+    return loader(data)
+
+read.__doc__ = read.__doc__.format(SLoader.__names__)
+
+
+@_ignore_bfd
+def write(results, /, format='json', fd=4):
+    """Write task state to file dsecriptor `fd` (defaulting to the Fate
+    standard state output descriptor).
+
+    State is presumed to be structured, *i.e.* in the form of a
+    `dict`. These will be serialized according to `format` (defaulting
+    to `json`). Supported formats include: `{}`.
+
+    Serialization may be disabled by setting `format` to `None`.
+
+    """
+    try:
+        dumper = str if format is None else Dumper[format]
+    except KeyError:
+        raise ValueError(f"unsupported format: {format!r}")
+
+    serialized = dumper(results)
+
+    with open(fd, 'w') as file:
+        file.write(serialized)
+
+write.__doc__ = write.__doc__.format(Dumper.__names__)

--- a/src/fate/util/animals.py
+++ b/src/fate/util/animals.py
@@ -1,0 +1,4 @@
+animals = ('aardvark', 'bison', 'canary', 'dalmation', 'emu', 'falcon', 'gnu',
+           'hamster', 'impala', 'jellyfish', 'kiwi', 'lemur', 'manatee',
+           'nutria', 'okapi', 'porcupine', 'quetzal', 'roadrunner', 'seal',
+           'turtle', 'unicorn', 'vole', 'wombat', 'xerus', 'yak', 'zebra')

--- a/src/fate/util/datastructure/__init__.py
+++ b/src/fate/util/datastructure/__init__.py
@@ -6,6 +6,7 @@ from .access import (  # noqa: F401
 )
 
 from .collection import (  # noqa: F401
+    ProxyDict,
     ProxyList,
 )
 


### PR DESCRIPTION
initial working draft of task state persistence via anonymous pipe
communication with the task subprocess.

each task subprocess is provisioned with a state-in pipe and a state-out
pipe -- dup'd to file descriptors 3 and 4 (respectively) -- for simple
and conventional readable input of a task's existing state and writable
output of a task's updated state for persistence.

the `fate.task` sdk package is extended with helpers for reading and
writing (structured) state in sub-package `fate.task.state`.

task state is persisted on disk via lmdb.

---

further includes refactoring of library's state directory, with conf-dedicated subdirectory at root; _etc_.